### PR TITLE
RT#148548 use separate name for export when generating constants

### DIFF
--- a/Sugar.pm
+++ b/Sugar.pm
@@ -66,7 +66,8 @@ sub import {
 	    if (ref $atoms eq 'ARRAY') {
 		foreach (@{$atoms}) {
 		    my $atom=$_;
-		    export sub () { $atom }, $to, $atom;
+		    my $name=$atom;
+		    export sub () { $atom }, $to, $name;
 		}
 	    }
 	    elsif (ref $atoms eq 'HASH') {

--- a/t/1.t
+++ b/t/1.t
@@ -8,6 +8,8 @@
 use Test::More tests => 1;
 BEGIN { use_ok('Language::Prolog::Sugar') };
 
+Language::Prolog::Sugar->import( atoms =>[qw(foo bar)] );
+
 #########################
 
 # Insert your test code below, the Test::More module is use()ed here so read


### PR DESCRIPTION
Fixes <https://rt.cpan.org/Public/Bug/Display.html?id=148548>.

Thanks @ology and @haarg.
